### PR TITLE
update for new longevity test

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -824,7 +824,21 @@ class ChaosMonkey(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.call_random_disrupt_method()
+        # Limit the nemesis scope:
+        #  - NodeToolCleanupMonkey
+        #  - DecommissionMonkey
+        #  - DrainerMonkey
+        #  - RefreshMonkey
+        #  - StopStartMonkey
+        #  - MajorCompactionMonkey
+        #  - ModifyTableMonkey
+        #  - EnospcMonkey
+        #  - StopWaitStartMonkey
+        self.call_random_disrupt_method(disrupt_methods=['disrupt_nodetool_cleanup', 'disrupt_nodetool_decommission',
+                                                         'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
+                                                         'disrupt_stop_start_scylla_server', 'disrupt_major_compaction',
+                                                         'disrupt_modify_table', 'disrupt_nodetool_enospc',
+                                                         'disrupt_stop_wait_start_scylla_server'])
 
 
 class AllMonkey(Nemesis):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -267,7 +267,10 @@ class Nemesis(object):
                 self._terminate_cluster_node(self.target_node)
                 # Replace the node that was terminated.
                 if add_node:
-                    self._add_and_init_new_cluster_node(target_node_ip)
+                    new_node = self._add_and_init_new_cluster_node(target_node_ip)
+                for node in self.db_cluster.nodes:
+                    if node not in [self.target_node, new_node]:
+                        node.remoter.run('nodetool --host localhost cleanup keyspace1', verbose=True)
 
     def disrupt_terminate_and_replace_node(self):
         # using "Replace a Dead Node" procedure from http://docs.scylladb.com/procedures/replace_dead_node/

--- a/tests/2-1-longevity-200GB-verifier.yaml
+++ b/tests/2-1-longevity-200GB-verifier.yaml
@@ -1,12 +1,12 @@
 test_duration: 10080
 prepare_write_cmd: "cassandra-stress write cl=ALL n=210200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300"
 prepare_verify_cmd: "cassandra-stress read cl=ALL n=210200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300"
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra s-rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -log interval=5"]
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -mode cql3 native user=cassandra password=cassandra -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -port jmx=6868 -log interval=5"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra s-rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=900200300..1100200300 -log interval=5"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=10080m -mode cql3 native user=cassandra password=cassandra -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -port jmx=6868 -log interval=5"]
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
-nemesis_class_name: 'DecommissionMonkey'
+nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
 nemesis_during_prepare: 'false'
 user_prefix: 'longevity-tls-1tb-with-verifier'

--- a/tests/enterprise2018-NO_TLS-longevity-200GB-verifier.yaml
+++ b/tests/enterprise2018-NO_TLS-longevity-200GB-verifier.yaml
@@ -1,12 +1,12 @@
 test_duration: 10080
 prepare_write_cmd: "cassandra-stress write cl=ALL n=210200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300"
 prepare_verify_cmd: "cassandra-stress read cl=ALL n=210200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300"
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra s-rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -log interval=5"]
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -mode cql3 native user=cassandra password=cassandra -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -port jmx=6868 -log interval=5"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra s-rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=900200300..1100200300 -log interval=5"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=10080m -mode cql3 native user=cassandra password=cassandra -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -port jmx=6868 -log interval=5"]
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
-nemesis_class_name: 'DecommissionMonkey'
+nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
 nemesis_during_prepare: 'false'
 user_prefix: 'longevity-tls-1tb-with-verifier'

--- a/tests/enterprise2018-longevity-200GB-verifier.yaml
+++ b/tests/enterprise2018-longevity-200GB-verifier.yaml
@@ -1,12 +1,12 @@
 test_duration: 10080
 prepare_write_cmd: "cassandra-stress write cl=ALL n=210200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300"
 prepare_verify_cmd: "cassandra-stress read cl=ALL n=210200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300"
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra s-rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -log interval=5"]
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -mode cql3 native user=cassandra password=cassandra -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -port jmx=6868 -log interval=5"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra s-rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=900200300..1100200300 -log interval=5"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=10080m -mode cql3 native user=cassandra password=cassandra -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..210200300 -port jmx=6868 -log interval=5"]
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
-nemesis_class_name: 'DecommissionMonkey'
+nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
 nemesis_during_prepare: 'false'
 user_prefix: 'longevity-tls-1tb-with-verifier'


### PR DESCRIPTION
The stress workload was adjusted, and we only run limited nemesis. Cleanup original nodes when new node is added back in decommission testing.

@roydahan 