### PR TITLE
improvement(calculate latency for perf): added in nemesis.py

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    params: params,
+
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: "test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+
+    timeout: [time: 1600, unit: "MINUTES"]
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2735,6 +2735,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         else:
             raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
         self.coredumps = dict()
+        self.latency_results = dict()
         super(BaseCluster, self).__init__()
 
     @cached_property

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1960,6 +1960,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.log.info('hot reloading internode ssl nemesis finished')
 
+    def disrupt_run_unique_sequence(self):
+        self.disrupt_mgmt_repair_cli()
+        time.sleep(180)
+        self.disrupt_terminate_and_replace_node()
+        time.sleep(180)
+        self.disrupt_grow_shrink_cluster()
+
 
 class NotSpotNemesis(Nemesis):
     def set_target_node(self):
@@ -2684,6 +2691,17 @@ class GeminiNonDisruptiveChaosMonkey(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
+
+
+class NemesisSequence(Nemesis):
+    disruptive = True
+    networking = False
+    run_with_gemini = False
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_run_unique_sequence()
+
 
 
 # Disable unstable streaming err nemesises

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -493,6 +493,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         old_node_ip = self.target_node.ip_address
         InfoEvent(message='StartEvent - Terminate node and wait 5 minutes')
         self._terminate_cluster_node(self.target_node)
+        time.sleep(300)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
         InfoEvent(message='FinishEvent - target_node was terminated')
         new_node = self._add_and_init_new_cluster_node(old_node_ip)
 
@@ -2713,7 +2714,6 @@ class NemesisSequence(Nemesis):
         self.disrupt_run_unique_sequence()
 
 
-
 # Disable unstable streaming err nemesises
 #
 # class DecommissionStreamingErrMonkey(Nemesis):
@@ -2741,7 +2741,6 @@ class NemesisSequence(Nemesis):
 #     @log_time_elapsed_and_status
 #     def disrupt(self):
 #         self.disrupt_repair_streaming_err()
-
 
 RELATIVE_NEMESIS_SUBCLASS_LIST = [NotSpotNemesis]
 

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -1,0 +1,38 @@
+test_duration: 1400
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..62500000",
+                    "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=62500001..125000000",
+                    "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=125000001..187500000",
+                    "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=187500001..250000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=700m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=700m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=700m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c4.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3.2xlarge'
+
+nemesis_class_name: 'NemesisSequence'
+nemesis_interval: 30
+
+user_prefix: 'perf-latency-nemesis'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5'
+backtrace_decoding: false
+
+use_mgmt: true
+mgmt_port: 10090
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2019.1.repo'
+scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.1.repo'
+
+store_perf_results: true
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-500gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-with-nemesis.yaml
@@ -1,0 +1,38 @@
+test_duration: 1400
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..125000000",
+                    "cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=125000001..250000000",
+                    "cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=250000001..375000000",
+                    "cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=375000001..500000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=360m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=6000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=360m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=360m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=4500/s'  -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
+
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c4.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3.2xlarge'
+
+nemesis_class_name: 'NemesisSequence'
+nemesis_interval: 15
+
+user_prefix: 'perf-latency-nemesis'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+backtrace_decoding: false
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 500'
+
+use_mgmt: true
+mgmt_port: 10090
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2019.1.repo'
+scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.1.repo'
+
+store_perf_results: true
+send_email: true
+email_recipients: ['qa@scylladb.com']


### PR DESCRIPTION
a function that will calculate all the performance latency
we want to show, and called it during the admin ops nemesis
class.

the "max" still need to be done (i'm not sure which metric and how to fetch it)
also, i'm doing it so far only for write load, as i want to add a dynamic call that will identify which test is running, and based on it, will run the needed metrics (it will be: `[read]`, `[write]` or `[read, write]`)